### PR TITLE
Clean up concurrency

### DIFF
--- a/Sources/Pulse/LoggerStore/LoggerStore.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore.swift
@@ -210,7 +210,9 @@ public final class LoggerStore: @unchecked Sendable, Identifiable {
 
         if !isArchive && !options.contains(.readonly) {
             try save(manifest)
-            sweepIfNeeded()
+            DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(10)) { [weak self] in
+              self?.sweepIfNeeded()
+            }
         }
     }
 
@@ -1077,9 +1079,7 @@ extension LoggerStore {
 extension LoggerStore {
     public func sweepIfNeeded() {
         guard isAutomaticSweepNeeded else { return }
-        DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(10)) { [weak self] in
-            self?.sweep()
-        }
+        sweep()
     }
 
     var isAutomaticSweepNeeded: Bool {


### PR DESCRIPTION
I realized that existing LoggerStore code was mutating manifest on a background thread, and generally it seems like this class is not built to be thread safe. This isn't a silver bullet, but the main thread should be a safer place to do this kind of thing than a background thread

Purging the store happens in a background managed object context, so it shouldn't matter what the calling thread is